### PR TITLE
update jumbotron template conditionals

### DIFF
--- a/base.php
+++ b/base.php
@@ -27,7 +27,7 @@
     <div role="document">
       <?php
         $fields = $fields = function_exists('get_fields') ? get_fields() : null;
-        if (is_array($fields['jumbotron_header'])){
+        if ((count($fields['jumbotron_header']) > 0)){
             get_template_part('templates/jumbotron-header');
         }
       ?>

--- a/templates/page-header.php
+++ b/templates/page-header.php
@@ -1,5 +1,5 @@
 <?php $is_jumbortron_header = function_exists('get_fields') ? get_field( "jumbotron_header" ) : null; ?>
-<?php if(!is_front_page() && !is_array($is_jumbortron_header)): ?>
+<?php if(!is_front_page() && (count($is_jumbortron_header) < 1 )): ?>
 
 <ol class="breadcrumb" typeof="BreadcrumbList" vocab="http://schema.org/">
         <?php if(function_exists('bcn_display'))


### PR DESCRIPTION
Testing a fix to the jumbotron headers for WP pages. It seems ACF updated their code at some point and a conditional needed some tweaking.