### PR TITLE
Multipage menu fix

### DIFF
--- a/base.php
+++ b/base.php
@@ -36,7 +36,7 @@
             <?php if (!is_front_page()): ?>
             <div class="container" id="#mainContent" tabindex="-1">
                 <?php
-                if(isset($fields['multipage_menu']) && $fields['multipage_menu'] !== false){
+                if(isset($fields['multipage_menu']) && !(empty($fields['multipage_menu'])) ){
                     set_query_var('multipage_menu', wp_get_nav_menu_items($fields['multipage_menu']));
                     get_template_part('templates/content-page-submenu');
                 }

--- a/base.php
+++ b/base.php
@@ -36,7 +36,7 @@
             <?php if (!is_front_page()): ?>
             <div class="container" id="#mainContent" tabindex="-1">
                 <?php
-                if(isset($fields['multipage_menu']) && $fields['multipage_menu'] !== false && (count($field['multipage_menu']) > 0)){
+                if(isset($fields['multipage_menu']) && $fields['multipage_menu'] !== false){
                     set_query_var('multipage_menu', wp_get_nav_menu_items($fields['multipage_menu']));
                     get_template_part('templates/content-page-submenu');
                 }


### PR DESCRIPTION
Updated last fix. The ACF field wasn't an array, so it was always returning false. However, I'm not *sure* that ACF field is a string, so I decided to use !empty instead of being specific about the value. We'll see!