### PR TITLE
update conditional to check for empty instead of count

### DIFF
--- a/base.php
+++ b/base.php
@@ -27,7 +27,7 @@
     <div role="document">
       <?php
         $fields = $fields = function_exists('get_fields') ? get_fields() : null;
-        if ((count($fields['jumbotron_header']) > 0)){
+        if (!empty($fields['jumbotron_header'])){
             get_template_part('templates/jumbotron-header');
         }
       ?>


### PR DESCRIPTION
PHP error log monitor threw a warning every time the homepage was visited (oops!). I didn't realize the array contained a string, so I changed it to empty instead of count. 