### PR TITLE
count() error now empty()

### DIFF
--- a/templates/page-header.php
+++ b/templates/page-header.php
@@ -1,5 +1,5 @@
 <?php $is_jumbortron_header = function_exists('get_fields') ? get_field( "jumbotron_header" ) : null; ?>
-<?php if(!is_front_page() && (count($is_jumbortron_header) < 1 )): ?>
+<?php if(!is_front_page() && (empty($is_jumbortron_header))): ?>
 
 <ol class="breadcrumb" typeof="BreadcrumbList" vocab="http://schema.org/">
         <?php if(function_exists('bcn_display'))


### PR DESCRIPTION
Started getting WP error log warnings for `page-header.php`... here we are.