### PR TITLE
fix boostrap and jquery collapse issue

### DIFF
--- a/intranet/inc/voyrequest.js
+++ b/intranet/inc/voyrequest.js
@@ -1,15 +1,19 @@
  jQuery(document).ready(function ($) {
      $("#hide-lib").click(function () {
          $("div#library").hide('slow');
+         $("div#library").removeClass('in');
      });
      $("#show-lib").click(function () {
          $("div#library").show('slow');
+         $("div#library").addClass('in');
      });
      $("#hide-loc").click(function () {
          $("div#location").hide('slow');
+         $("div#location").removeClass('in');
      });
      $("#show-loc").click(function () {
          $("div#location").show('slow');
+         $("div#location").addClass('in');
      });
      $("#hide-type").click(function () {
          $("div#type").hide('slow');


### PR DESCRIPTION
I failed to test all the dropdown options in the Voyager report request form. This fixes a bug where some of the divs were using "collapse" but the content in the div wasn't being shown when uncollapsed. 🤷‍♀️