### PR TITLE
Add more specific styles to dropdowns in jumbotron

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -9679,6 +9679,9 @@ footer > .sub-footer {
   margin-left: -10px;
   margin-bottom: 21px;
 }
+.jumbotron-header > .jumbotron .dropdown a {
+  color: #990000;
+}
 .ualib-image-carousel {
   position: relative;
 }


### PR DESCRIPTION
This prevents the overeagerness of the jumbotron's style for `a` as white text from affecting nav dropdowns (which have a white backdrop on links, requiring the default link color to be restored).

Current:
![image](https://user-images.githubusercontent.com/8005215/135147264-f2b3293b-2e76-478b-9c18-4b7f5dfe0946.png)
Fixed:
![image](https://user-images.githubusercontent.com/8005215/135147294-ba6cc248-bcc4-4b13-a8eb-24908ff6e767.png)
